### PR TITLE
Skip xanmod install if already active

### DIFF
--- a/opvpn-setup.sh
+++ b/opvpn-setup.sh
@@ -47,6 +47,11 @@ check_os() {
 
 # Funzione installazione kernel xanmod (solo TCP)
 install_xanmod_kernel() {
+    # Verifica se il kernel xanmod è già in esecuzione e BBR è abilitato
+    if uname -r | grep -qi xanmod && [ "$(sysctl -n net.ipv4.tcp_congestion_control 2>/dev/null)" = "bbr" ]; then
+        echo "Kernel xanmod e BBR già attivi, salto reinstallazione."
+        return
+    fi
     echo "Installo kernel xanmod e abilito BBR per TCP..."
     apt-get update
     apt-get install -y wget curl gnupg


### PR DESCRIPTION
## Summary
- avoid reinstalling xanmod if kernel already xanmod and BBR enabled

## Testing
- `shellcheck opvpn-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f82ad3f508327ae8edfb13406f9d6