### PR TITLE
Fix client status detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will install openvpn on the server, configure it, Re-Run the script to get th
 3) add a new vpn client
 4) remove a vpn client
 5) list current client 
-6) check client status (checks who is connected via openvpn status and via ping)
+6) check client status (shows VPN IP, real address and connection time)
 7) check if the script has been updated and optionally update
 8) put the script in /usr/bin so that you can call the script with the name opvpn-setup (toggle add/remove)
 9) uninstall everything and remove all tunnel files

--- a/opvpn-setup.sh
+++ b/opvpn-setup.sh
@@ -445,16 +445,34 @@ list_clients() {
 # Stato client
 check_client_status() {
     echo "Stato client:"
+
+    # Determine status file paths from configs if defaults are missing
+    local udp_status="/var/log/openvpn-udp-status.log"
+    local tcp_status="/var/log/openvpn-tcp-status.log"
+
+    [ -f "$udp_status" ] || udp_status=$(grep -m1 '^status ' /etc/openvpn/server_udp.conf 2>/dev/null | awk '{print $2}')
+    [ -f "$tcp_status" ] || tcp_status=$(grep -m1 '^status ' /etc/openvpn/server_tcp.conf 2>/dev/null | awk '{print $2}')
+
     for cert in "$EASYRSA_DIR"/pki/issued/*.crt; do
         [ -e "$cert" ] || continue
         client=$(basename "$cert")
         [ "$client" = "ca.crt" ] && continue
-        [ "$certname" = "server.crt" ] && continue
+        [ "$client" = "server.crt" ] && continue
         client=${client%.crt}
-        ip=$(grep "$client" /var/log/openvpn-udp-status.log 2>/dev/null | awk '{print $1}')
-        [ -z "$ip" ] && ip=$(grep "$client" /var/log/openvpn-tcp-status.log 2>/dev/null | awk '{print $1}')
-        if [ -n "$ip" ]; then
-            echo "$client ONLINE ($ip)"
+
+        status_line=$(grep "^CLIENT_LIST,$client," "$udp_status" 2>/dev/null || \
+                     grep "^CLIENT_LIST,$client," "$tcp_status" 2>/dev/null)
+
+        if [ -n "$status_line" ]; then
+            IFS=',' read -r _ _ real_addr _ _ connect_since <<< "$status_line"
+            routing_line=$(grep "^ROUTING_TABLE,.*,$client," "$udp_status" 2>/dev/null || \
+                           grep "^ROUTING_TABLE,.*,$client," "$tcp_status" 2>/dev/null)
+            if [ -n "$routing_line" ]; then
+                IFS=',' read -r _ virtual_addr _ _ _ <<< "$routing_line"
+            else
+                virtual_addr="N/A"
+            fi
+            echo "$client ONLINE (VPN: $virtual_addr, Real: $real_addr, Since: $connect_since)"
         else
             echo "$client offline"
         fi


### PR DESCRIPTION
## Summary
- look up status log paths from config if default logs are missing

## Testing
- `bash -n opvpn-setup.sh`
- `shellcheck opvpn-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6880baf267f08327ad0b637703ccd2c3