### PR TITLE
Use sudo in PHP web GUI

### DIFF
--- a/webgui.php
+++ b/webgui.php
@@ -37,7 +37,7 @@ function list_clients($dir) {
 function run_cmd($cmd) {
     $output = [];
     $ret = 0;
-    exec($cmd . ' 2>&1', $output, $ret);
+    exec('sudo ' . $cmd . ' 2>&1', $output, $ret);
     return [implode("\n", $output), $ret === 0];
 }
 


### PR DESCRIPTION
## Summary
- call sudo in run_cmd so PHP-based GUI can run OpenVPN setup tasks with elevated privileges

## Testing
- `php -l webgui.php`
- `bash -n opvpn-setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6880c91fec78832789aad8911f77cb4a